### PR TITLE
added array arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ src --> sharedStream1    -->  stream2 -->
 
 **if mirror has only one argument, it will create another passthrough stream, just like [gulp-clone](https://github.com/mariocasciaro/gulp-clone)**, See [example 3](https://github.com/popomore/gulp-mirror/tree/master/examples#example-3).
 
+### mirror([stream1, stream2 ..., streamN])
+
+Sometimes the number of streams is variable, then we can pass to `mirror` an array of streams as unique argument.
+
 ## LICENSE
 
 Copyright (c) 2015 popomore. Licensed under the MIT license.

--- a/index.js
+++ b/index.js
@@ -8,7 +8,11 @@ var pedding = require('pedding');
 
 module.exports = function() {
   var output = through.obj();
-  var streams = Array.prototype.slice.call(arguments);
+  if (arguments.length == 1 && Object.prototype.toString.call(arguments[0]) === '[object Array]') {
+    var streams = arguments[0];
+  } else {
+    var streams = Array.prototype.slice.call(arguments);
+  }
 
   // if no stream, just return a passthrough stream
   if (streams.length === 0) {

--- a/test/index.js
+++ b/test/index.js
@@ -31,6 +31,30 @@ describe('gulp-mirror', function() {
     stream.end();
   });
 
+  it('should mirror with arrays', function(done) {
+    var streamA = through.obj(function(buf, enc, cb) {
+      cb(null, buf + 1);
+    });
+    var streamB = through.obj(function(buf, enc, cb) {
+      cb(null, buf * 10);
+    });
+
+    var ret = [];
+    var stream = mirror([streamA, streamB]);
+    stream
+    .on('data', function(data) {
+      ret.push(data);
+    })
+    .on('end', function() {
+      ret.should.eql([2, 10, 3, 20]);
+      done();
+    });
+
+    stream.write(1);
+    stream.write(2);
+    stream.end();
+  });
+
   it('should error handle', function(done) {
     var errorStream = through.obj(function(buf, enc, cb) {
       cb(new Error('err'));
@@ -74,6 +98,33 @@ describe('gulp-mirror', function() {
     stream.end();
   });
 
+  it('should end after all stream are end when passing array', function(done) {
+    var streamNormal = through.obj(function(buf, enc, cb) {
+      cb(null, buf + 1);
+    });
+
+    var streamSlow = through.obj(function(buf, enc, cb) {
+      setTimeout(function() {
+        cb(null, buf - 1);
+      }, 1000);
+    });
+
+    var ret = [];
+    var stream = mirror([streamNormal, streamSlow])
+    .on('data', function(data) {
+      ret.push(data);
+    })
+    .on('error', function(e) {
+      should.not.exist(e);
+    })
+    .on('end', function() {
+      ret.should.eql([2, 0]);
+      done();
+    });
+
+    stream.write(1);
+    stream.end();
+  });
   it('should be passthrough stream when no argument', function(done) {
     var ret = [], stream = mirror()
     .on('data', function(data) {
@@ -120,6 +171,77 @@ describe('gulp-mirror', function() {
 
       var ret = [];
       var stream = mirror(streamA, streamB)
+      .on('data', function(data) {
+        ret.push(data);
+      })
+      .on('end', function() {
+        cb(ret);
+      });
+
+      stream.write(writeCode);
+      stream.end();
+    }
+
+    it('should equal number', function(done) {
+      testClone(1, function(ret) {
+        ret[0].should.equal(ret[1]);
+        done();
+      });
+    });
+
+    it('should equal array', function(done) {
+      testClone([1, 2], function(ret) {
+        ret[0].should.not.equal(ret[1]);
+        ret[0].should.eql(ret[1]);
+        done();
+      });
+    });
+
+    it('should equal object', function(done) {
+      testClone({a: 1}, function(ret) {
+        ret[0].should.not.equal(ret[1]);
+        ret[0].should.eql(ret[1]);
+        done();
+      });
+    });
+
+    it('should equal buffer', function(done) {
+      testClone(new Buffer('abc'), function(ret) {
+        ret[0].should.not.equal(ret[1]);
+        ret[0].toString().should.eql(ret[1].toString());
+        done();
+      });
+    });
+
+    it('should equal vinyl', function(done) {
+      var file = new File({
+        path: 'a.js',
+        cwd: __dirname,
+        base: __dirname,
+        contents: new Buffer('abc')
+      });
+      file.originPath = file.path;
+
+      testClone(file, function(ret) {
+        ret[0].should.not.equal(ret[1]);
+        ret[0].contents.should.not.equal(ret[1].contents);
+        ret[0].contents.toString().should.equal(ret[1].contents.toString());
+        ret[0].path.should.equal(ret[1].path);
+        ret[0].cwd.should.equal(ret[1].cwd);
+        ret[0].base.should.equal(ret[1].base);
+        ret[0].originPath.should.equal(ret[1].originPath);
+        done();
+      });
+    });
+  });
+  describe('file clone with arrays', function() {
+
+    function testClone(writeCode, cb) {
+      var streamA = through.obj();
+      var streamB = through.obj();
+
+      var ret = [];
+      var stream = mirror([streamA, streamB])
       .on('data', function(data) {
         ret.push(data);
       })


### PR DESCRIPTION
`mirror` accepts now an array of streams instead of multiple streams passed as bare arguments. Example: `mirror([s1, s2, s3])`. This has been required in one of my projects since the amount of forks we have to execute depends on the amount of countries declared in our configuration file.

Tests have been copied replacing the enumeration of streams with the same streams packed in an array. All tests passes.

The walk around right now is hacking function call:

```
pipes = [s1, s2, s3]; // actually generated in a for loop
mirror.apply(this, pipes);
```

Thanks.
